### PR TITLE
Fix CI dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('src/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r src/requirements.txt
+      - name: Lint with flake8
+        run: |
+          flake8 src tests
+      - name: Compile Python files
+        run: |
+          python -m py_compile $(git ls-files '*.py')
+      - name: Run tests
+        run: |
+          pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+.eggs/
+*.sqlite3
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# BAN
-Body Area Network (Hub)
+# Body Area Network Hub (BAN Hub)
+
+This project aims to provide a universal hub for managing personal devices such as wearables and sensors. It supports Bluetooth and Wi-Fi communication with optional USB connectivity.
+
+## Directory Structure
+
+- `docs/` — Documentation and setup guides.
+- `hardware/` — Schematics and hardware assembly instructions.
+- `src/` — Source code for the hub software.
+- `examples/` — Sample scripts demonstrating hub usage.
+
+## Quick Start
+
+1. Assemble the hardware using the instructions in `hardware/`.
+2. Install Python dependencies:
+   ```bash
+   cd src
+   pip install -r requirements.txt
+   # Bluetooth support requires PyBluez which may not
+   # compile on Python versions newer than 3.10.
+   # Skip this if installation fails or you don't need Bluetooth.
+   pip install pybluez || true
+   ```
+3. Run the hub:
+   ```bash
+   python hub.py
+   ```
+4. Run lint and tests:
+   ```bash
+   flake8 src tests
+   pytest -q
+   ```
+
+Refer to `docs/setup.md` for more details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation
+
+This folder contains guides and documentation for building and using the BAN Hub.
+
+* `setup.md` - Setup instructions.
+* `contributing.md` - Guidelines for contributing.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,7 @@
+# Contributing Guide
+
+Thank you for considering contributing to the BAN Hub project!
+
+1. Fork the repository and create your feature branch.
+2. Commit your changes with clear messages.
+3. Open a pull request describing your changes.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,17 @@
+# Setup Guide
+
+This document provides an overview of how to set up the BAN Hub.
+
+1. Assemble the hardware following the instructions in the `hardware` directory.
+2. Navigate to the `src` directory and install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   # Bluetooth support requires PyBluez, but it may not
+   # compile on newer Python versions. Skip this step if
+   # installation fails or you do not need Bluetooth.
+   pip install pybluez || true
+   ```
+3. Run the hub:
+   ```bash
+   python hub.py
+   ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+Sample code demonstrating how to connect devices to the BAN Hub.
+
+See the individual example scripts for more details.

--- a/examples/scan.py
+++ b/examples/scan.py
@@ -1,0 +1,11 @@
+"""Example script that scans for nearby Bluetooth and Wi-Fi devices using the hub."""
+from pathlib import Path
+import sys
+
+# Ensure src directory is on path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from hub import main
+
+if __name__ == '__main__':
+    main()

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,0 +1,5 @@
+# Hardware
+
+Schematics and instructions for assembling the BAN Hub hardware components.
+
+Refer to `schematics` and `assembly.md` for detailed information.

--- a/hardware/assembly.md
+++ b/hardware/assembly.md
@@ -1,0 +1,5 @@
+# Hardware Assembly
+
+1. Mount the Bluetooth and Wi-Fi modules on your development board.
+2. Connect optional sensors to the board's GPIO or USB ports.
+3. Power the board and verify that all modules are detected.

--- a/hardware/schematics/README.md
+++ b/hardware/schematics/README.md
@@ -1,0 +1,1 @@
+Schematics will be added here to illustrate wiring and connections for the BAN Hub.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,6 @@
+# BAN Hub Source Code
+
+This directory contains the source code for the BAN Hub software. The code is structured as follows:
+
+* `hub.py` - Main entry point for running the hub.
+* `requirements.txt` - Python dependencies.

--- a/src/hub.py
+++ b/src/hub.py
@@ -1,0 +1,49 @@
+"""Simple BAN Hub skeleton."""
+
+import logging
+
+try:
+    import bluetooth
+except ImportError:
+    bluetooth = None
+
+try:
+    import wifi
+except ImportError:
+    wifi = None
+
+
+def scan_bluetooth_devices():
+    if not bluetooth:
+        logging.warning(
+            "PyBluez is not installed. Bluetooth scanning unavailable."
+        )
+        return []
+    logging.info("Scanning for Bluetooth devices...")
+    return bluetooth.discover_devices(duration=8, lookup_names=True)
+
+
+def scan_wifi_networks():
+    if not wifi:
+        logging.warning(
+            "wifi library is not installed. Wi-Fi scanning unavailable."
+        )
+        return []
+    logging.info("Scanning for Wi-Fi networks...")
+    cells = wifi.Cell.all('wlan0')
+    return [(cell.ssid, cell.address) for cell in cells]
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    bt_devices = scan_bluetooth_devices()
+    for addr, name in bt_devices:
+        logging.info("Found Bluetooth device %s at %s", name, addr)
+
+    wifi_networks = scan_wifi_networks()
+    for ssid, bssid in wifi_networks:
+        logging.info("Found Wi-Fi network %s at %s", ssid, bssid)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,4 @@
+# Python dependencies for BAN Hub
+wifi
+flake8
+pytest

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def test_import_hub():
+    import hub
+    assert hasattr(hub, "main")


### PR DESCRIPTION
## Summary
- avoid pybluez build issues by dropping it from required packages
- cache pip dependencies and pin to Python 3.11 in workflow
- document optional Bluetooth dependency
- clarify that optional install may fail and add gitignore

## Testing
- `python3 -m flake8 src tests`
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686064bcacd48324b5dc08603e6b21d4