### PR TITLE
Improve BAN core scanning flow, compliance, and agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,22 @@ Purpose: Clarity, maintainability, zero confusion.
 - **Behaviors:** Logs a warning if bleak is unavailable, otherwise performs a discovery scan.
 - **Tests:** `tests/test_hub.py`
 
+### WiFiScanRoutine
+- **Purpose:** Discovers nearby Wi-Fi networks using the optional `wifi` package.
+- **Location:** `src/hub.py` (`scan_wifi_networks` function)
+- **Interface:** `def scan_wifi_networks(interface: str = "wlan0")` returns a list of `(ssid, bssid)` tuples.
+- **Triggers:** Invoked by `main()` or any caller needing a Wi-Fi scan.
+- **Behaviors:** Logs a warning if `wifi` is unavailable, otherwise scans the requested interface.
+- **Tests:** `tests/test_hub.py`
+
+### LoggingConfigRoutine
+- **Purpose:** Defines consistent runtime logging configuration for hub execution.
+- **Location:** `src/hub.py` (`configure_logging` function)
+- **Interface:** `def configure_logging() -> None`
+- **Triggers:** Called by `main()` during startup.
+- **Behaviors:** Sets INFO logging level and unified formatter for hub logs.
+- **Tests:** covered indirectly by runtime execution paths.
+
 ### HubMainLoop
 - **Purpose:** Coordinates Bluetooth and Wi-Fi scans when the hub starts.
 - **Location:** `src/hub.py` (`main` coroutine)
@@ -19,4 +35,3 @@ Purpose: Clarity, maintainability, zero confusion.
 - **Triggers:** Executed when running `python hub.py` or via the example script.
 - **Behaviors:** Logs discovered Bluetooth devices and Wi-Fi networks.
 - **Tests:** covered indirectly via unit tests of scan routines.
-

--- a/BODY.md
+++ b/BODY.md
@@ -1,0 +1,23 @@
+# BODY.md — BAN Physical/Runtime Surface
+
+## Runtime Components
+- **BluetoothScanRoutine**: async BLE scanner backed by `bleak`.
+- **WiFiScanRoutine**: sync Wi-Fi scanner backed by `wifi`.
+- **HubMainLoop**: orchestration entrypoint that executes scan routines.
+
+## Inputs and Outputs
+- **Bluetooth output:** list of `(address, name)` tuples.
+- **Wi-Fi output:** list of `(ssid, bssid)` tuples.
+- **Logging output:** informational and warning logs for scan state and results.
+
+## Operational Constraints
+- Bluetooth and Wi-Fi dependencies are optional and can be missing in minimal environments.
+- Default Wi-Fi interface is `wlan0`; callers may pass a different interface name.
+- Tests are deterministic through dependency monkeypatching.
+
+## Validation Surface
+- Unit tests in `tests/test_hub.py` cover:
+  - successful Bluetooth normalization,
+  - Bluetooth dependency-missing fallback,
+  - successful Wi-Fi normalization,
+  - Wi-Fi dependency-missing fallback.

--- a/MIND.md
+++ b/MIND.md
@@ -1,0 +1,21 @@
+# MIND.md — BAN Cognitive Map
+
+## Intent
+BAN is designed as a lightweight hub that discovers nearby Bluetooth and Wi-Fi devices with safe fallbacks when optional dependencies are unavailable.
+
+## Logic Flow (Dev Agent Breadcrumbs)
+1. Start in `src/hub.py::main`.
+2. Configure logging once.
+3. Run Bluetooth discovery asynchronously.
+4. Run Wi-Fi discovery synchronously.
+5. Normalize findings into simple tuples for portability.
+
+## Decision Rules
+- If `bleak` is not installed, return an empty Bluetooth result and emit a warning.
+- If `wifi` is not installed, return an empty Wi-Fi result and emit a warning.
+- Device names missing from Bluetooth scans are normalized to `"Unknown"`.
+
+## Near-Term Improvements
+- Make Wi-Fi interface configurable via environment variables or CLI flags.
+- Add retry policies and scan timeout controls.
+- Add structured output mode for integration with external services.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,38 @@
 # Body Area Network Hub (BAN Hub)
-[![CI](https://github.com/yourorg/BAN/actions/workflows/python.yml/badge.svg)](https://github.com/yourorg/BAN/actions/workflows/python.yml)
-[![codecov](https://codecov.io/gh/yourorg/BAN/branch/main/graph/badge.svg)](https://codecov.io/gh/yourorg/BAN)
 
-This project aims to provide a universal hub for managing personal devices such as wearables and sensors. It supports Bluetooth (via the `bleak` library) and Wi-Fi communication with optional USB connectivity.
+BAN Hub is a lightweight Python project for discovering nearby wearable/sensor connectivity endpoints over Bluetooth and Wi-Fi.
+
+## Core Capabilities
+- Asynchronous Bluetooth scanning via `bleak` (when installed).
+- Wi-Fi network scanning via `wifi` (when installed).
+- Safe fallback behavior when optional dependencies are unavailable.
+- Simple tuple outputs that are easy to integrate downstream.
 
 ## Directory Structure
-
-- `docs/` — Documentation and setup guides.
-- `hardware/` — Schematics and hardware assembly instructions.
-- `src/` — Source code for the hub software.
-- `examples/` — Sample scripts demonstrating hub usage.
+- `docs/` — setup and contribution documentation.
+- `hardware/` — hardware notes and assembly guidance.
+- `src/` — runtime source code.
+- `tests/` — unit tests for core logic.
+- `examples/` — runnable usage example.
 
 ## Quick Start
-
-1. Assemble the hardware using the instructions in `hardware/`.
-2. Install Python dependencies:
+1. Install dependencies:
    ```bash
-   cd src
-   pip install -r requirements.txt
+   pip install -r src/requirements.txt
    ```
-3. Run the hub:
+2. Run the hub:
    ```bash
-   python hub.py
+   python src/hub.py
    ```
-
-Refer to `docs/setup.md` for more details.
 
 ## Running Tests
-
-Run the test suite with `pytest`. Ensure the required testing
-dependencies are installed first:
-
 ```bash
-pip install -r src/requirements.txt
-pip install pytest pytest-asyncio pytest-cov
-pytest
+pip install pytest
+pytest -q
 ```
 
+## Dev Agent Breadcrumbs
+See logic breadcrumbs in:
+- `src/hub.py`
+- `examples/scan.py`
+- `MIND.md`, `BODY.md`, `SOUL.md`

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,16 @@
+# SOUL.md — BAN Principles
+
+## Guiding Values
+1. **Graceful Degradation**: Missing optional libraries should never crash baseline execution.
+2. **Readable Flow**: Every routine should be easy to reason about from top to bottom.
+3. **Small Interfaces**: Return compact, dependency-agnostic tuple structures.
+4. **Test-First Trust**: Core behavior should be validated by fast unit tests.
+
+## Dev Agent Breadcrumb Convention
+- Keep a short numbered breadcrumb block near orchestrators and scripts.
+- Use the same routine names in docs and code to reduce mapping friction.
+- Prefer explicit names (`bluetooth_devices`, `wifi_networks`) over abbreviated variables.
+
+## Collaboration Notes
+- Update this file whenever new routines or bots are introduced.
+- Mirror major routine changes in `AGENTS.md`, `MIND.md`, and `BODY.md`.

--- a/examples/scan.py
+++ b/examples/scan.py
@@ -1,13 +1,15 @@
-"""Example script that scans for nearby Bluetooth and Wi-Fi devices using the hub."""
-from pathlib import Path
-import sys
+"""Run BAN hub scans from the examples directory.
 
-# Ensure src directory is on path
-sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+Dev Agent Breadcrumbs
+---------------------
+1. Import the orchestrating ``main`` coroutine from ``src.hub``.
+2. Execute the async runtime with ``asyncio.run``.
+"""
 
-from hub import main
 import asyncio
 
-if __name__ == '__main__':
-    asyncio.run(main())
+from src.hub import main
 
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""BAN Hub source package."""

--- a/src/hub.py
+++ b/src/hub.py
@@ -1,46 +1,79 @@
-"""Simple BAN Hub skeleton using the bleak library for Bluetooth scanning."""
+"""BAN hub routines for Bluetooth and Wi-Fi discovery.
 
-import logging
+Dev Agent Breadcrumbs
+---------------------
+1. ``main`` orchestrates startup and scan execution.
+2. ``scan_bluetooth_devices`` returns normalized Bluetooth records.
+3. ``scan_wifi_networks`` returns normalized Wi-Fi records.
+"""
+
+from __future__ import annotations
+
 import asyncio
+import logging
+from typing import List, Tuple
+
+LOGGER = logging.getLogger(__name__)
+WIFI_INTERFACE = "wlan0"
 
 try:
     from bleak import BleakScanner
-except ImportError:
+except ImportError:  # pragma: no cover - environment dependent import
     BleakScanner = None
 
 try:
     import wifi
-except ImportError:
+except ImportError:  # pragma: no cover - environment dependent import
     wifi = None
 
 
-async def scan_bluetooth_devices():
-    if not BleakScanner:
-        logging.warning("bleak is not installed. Bluetooth scanning unavailable.")
+def configure_logging() -> None:
+    """Configure application logging for the BAN hub runtime."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+async def scan_bluetooth_devices() -> List[Tuple[str, str]]:
+    """Scan for Bluetooth devices and return ``(address, name)`` pairs."""
+    if BleakScanner is None:
+        LOGGER.warning(
+            "bleak is not installed. Bluetooth scanning unavailable."
+        )
         return []
-    logging.info("Scanning for Bluetooth devices...")
+
+    LOGGER.info("Scanning for Bluetooth devices...")
     devices = await BleakScanner.discover()
-    return [(d.address, d.name or "Unknown") for d in devices]
+    return [(device.address, device.name or "Unknown") for device in devices]
 
 
-def scan_wifi_networks():
-    if not wifi:
-        logging.warning("wifi library is not installed. Wi-Fi scanning unavailable.")
+def scan_wifi_networks(
+    interface: str = WIFI_INTERFACE,
+) -> List[Tuple[str, str]]:
+    """Scan for Wi-Fi networks and return ``(ssid, bssid)`` pairs."""
+    if wifi is None:
+        LOGGER.warning(
+            "wifi library is not installed. Wi-Fi scanning unavailable."
+        )
         return []
-    logging.info("Scanning for Wi-Fi networks...")
-    cells = wifi.Cell.all('wlan0')
+
+    LOGGER.info("Scanning for Wi-Fi networks on interface %s...", interface)
+    cells = wifi.Cell.all(interface)
     return [(cell.ssid, cell.address) for cell in cells]
 
 
-async def main():
-    logging.basicConfig(level=logging.INFO)
-    bt_devices = await scan_bluetooth_devices()
-    for addr, name in bt_devices:
-        logging.info("Found Bluetooth device %s at %s", name, addr)
+async def main() -> None:
+    """Run the BAN hub startup sequence and emit discovery results."""
+    configure_logging()
+
+    bluetooth_devices = await scan_bluetooth_devices()
+    for address, name in bluetooth_devices:
+        LOGGER.info("Found Bluetooth device %s at %s", name, address)
 
     wifi_networks = scan_wifi_networks()
     for ssid, bssid in wifi_networks:
-        logging.info("Found Wi-Fi network %s at %s", ssid, bssid)
+        LOGGER.info("Found Wi-Fi network %s at %s", ssid, bssid)
 
 
 if __name__ == "__main__":

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,30 +1,79 @@
-import pytest
-import types
+"""Unit tests for BAN hub discovery routines."""
+
 import asyncio
+from types import SimpleNamespace
 
-from pathlib import Path
-import sys
+from src import hub
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
-
-import hub
 
 class DummyDevice:
-    def __init__(self, address, name):
+    """Simple BLE device fixture for tests."""
+
+    def __init__(self, address: str, name: str | None) -> None:
         self.address = address
         self.name = name
 
-@pytest.mark.asyncio
-async def test_scan_bluetooth_devices(monkeypatch):
-    async def fake_discover():
-        return [DummyDevice("AA:BB:CC:DD:EE:FF", "Tester")]
+
+def test_scan_bluetooth_devices_returns_normalized_devices(monkeypatch):
+    """Bluetooth scan returns address/name tuples and fills unknown names."""
 
     class DummyScanner:
+        """Stub scanner with deterministic device list."""
+
         @staticmethod
         async def discover():
-            return await fake_discover()
+            return [
+                DummyDevice("AA:BB:CC:DD:EE:FF", "Tester"),
+                DummyDevice("11:22:33:44:55:66", None),
+            ]
 
     monkeypatch.setattr(hub, "BleakScanner", DummyScanner)
-    devices = await hub.scan_bluetooth_devices()
-    assert devices == [("AA:BB:CC:DD:EE:FF", "Tester")]
 
+    devices = asyncio.run(hub.scan_bluetooth_devices())
+
+    assert devices == [
+        ("AA:BB:CC:DD:EE:FF", "Tester"),
+        ("11:22:33:44:55:66", "Unknown"),
+    ]
+
+
+def test_scan_bluetooth_devices_without_bleak(monkeypatch):
+    """Bluetooth scan safely degrades when bleak is unavailable."""
+    monkeypatch.setattr(hub, "BleakScanner", None)
+
+    devices = asyncio.run(hub.scan_bluetooth_devices())
+
+    assert devices == []
+
+
+def test_scan_wifi_networks_returns_normalized_cells(monkeypatch):
+    """Wi-Fi scan returns SSID/BSSID pairs from the selected interface."""
+
+    called = {}
+
+    def fake_all(interface):
+        called["interface"] = interface
+        return [
+            SimpleNamespace(ssid="BAN-NET", address="00:11:22:33:44:55"),
+            SimpleNamespace(ssid="Guest", address="AA:AA:AA:AA:AA:AA"),
+        ]
+
+    dummy_wifi = SimpleNamespace(Cell=SimpleNamespace(all=fake_all))
+    monkeypatch.setattr(hub, "wifi", dummy_wifi)
+
+    networks = hub.scan_wifi_networks(interface="test0")
+
+    assert called["interface"] == "test0"
+    assert networks == [
+        ("BAN-NET", "00:11:22:33:44:55"),
+        ("Guest", "AA:AA:AA:AA:AA:AA"),
+    ]
+
+
+def test_scan_wifi_networks_without_wifi(monkeypatch):
+    """Wi-Fi scan safely degrades when wifi dependency is unavailable."""
+    monkeypatch.setattr(hub, "wifi", None)
+
+    networks = hub.scan_wifi_networks()
+
+    assert networks == []


### PR DESCRIPTION
### Motivation
- Make the hub runtime clearer and more maintainable by adding explicit logic breadcrumbs and stronger typing in `src/hub.py`.
- Ensure graceful degradation when optional dependencies (`bleak`, `wifi`) are missing so runtime does not crash.
- Fix tests and PEP8 issues so the project is testable in minimal environments without extra async pytest plugins.

### Description
- Refactored `src/hub.py` to add `configure_logging()`, typed scan functions (`scan_bluetooth_devices`, `scan_wifi_networks`), a `WIFI_INTERFACE` constant, and Dev Agent Breadcrumbs at the top of the file.
- Normalized Bluetooth/Wi‑Fi outputs to simple tuples and made `scan_wifi_networks(interface: str)` configurable, with safe fallbacks when `BleakScanner` or `wifi` are absent.
- Simplified example runner to import from `src.hub` and added `src/__init__.py` so the package can be imported cleanly in tests and examples.
- Expanded and PEP8-adjusted tests in `tests/test_hub.py` to use `asyncio.run` (avoiding `pytest-asyncio`) and added deterministic stubs for BLE and Wi‑Fi scans.
- Added documentation files `MIND.md`, `BODY.md`, and `SOUL.md`, and updated `AGENTS.md` and `README.md` to document logic flow, runtime surface, and guiding principles.

### Testing
- Ran `pycodestyle src tests examples` to validate PEP8 formatting, which passed after adjustments.
- Compiled sources with `python -m compileall src tests examples` to ensure module importability, which succeeded.
- Executed the test suite with `pytest -q`, and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1fecd7650832496f097390fd1bca5)